### PR TITLE
Optionally create a subkey, is subkey_length is positive number.

### DIFF
--- a/templates/gen-key-script
+++ b/templates/gen-key-script
@@ -2,8 +2,10 @@
 %echo Generating a basic OpenPGP key
 Key-Type: 1
 Key-Length: {{ gpg_keylength }}
+{% if gpg_subkeylength > 0 %}
 Subkey-Type: 1
 Subkey-Length: {{ gpg_subkeylength }}
+{% endif %}
 Name-Real: {{ gpg_realname }}
 Name-Email: {{ gpg_useremail }}
 Expire-Date: {{ gpg_expire }}


### PR DESCRIPTION
Some system using GPG doesn't support signing subkeys (I'm especially thinking about RPM).
This patch does allow to not create a subkey setting `gpg_subkeylength` to 0.