### PR TITLE
Reuse recently updated APT cache

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -29,3 +29,5 @@ gpg_pulldir: tmp
 
 gpg_conf_file_template: gpg.conf.j2
 gpg_gen_key_script_template: gen-key-script
+
+gpg_apt_cache_valid_time: 3600 # 1 hour

--- a/tasks/gpgkey_generate.yml
+++ b/tasks/gpgkey_generate.yml
@@ -14,7 +14,7 @@
       - acl
     state: present
     update_cache: yes
-    cache_valid_time: 7200 #2 hours
+    cache_valid_time: "{{ gpg_apt_cache_valid_time }}"
   when: >
     (ansible_distribution == 'Debian' and ansible_distribution_version|int >= 7) or
     (ansible_distribution == 'Ubuntu' and ansible_distribution_version|int >= 14)
@@ -28,7 +28,7 @@
       - gnupg
     state: present
     update_cache: yes
-    cache_valid_time: 7200 #2 hours
+    cache_valid_time: "{{ gpg_apt_cache_valid_time }}"
   when: >
     (ansible_distribution == 'Debian' and ansible_distribution_version|int < 7) or
     (ansible_distribution == 'Ubuntu' and ansible_distribution_version|int < 14)

--- a/tasks/gpgkey_generate.yml
+++ b/tasks/gpgkey_generate.yml
@@ -14,6 +14,7 @@
       - acl
     state: present
     update_cache: yes
+    cache_valid_time: 7200 #2 hours
   when: >
     (ansible_distribution == 'Debian' and ansible_distribution_version|int >= 7) or
     (ansible_distribution == 'Ubuntu' and ansible_distribution_version|int >= 14)
@@ -27,6 +28,7 @@
       - gnupg
     state: present
     update_cache: yes
+    cache_valid_time: 7200 #2 hours
   when: >
     (ansible_distribution == 'Debian' and ansible_distribution_version|int < 7) or
     (ansible_distribution == 'Ubuntu' and ansible_distribution_version|int < 14)


### PR DESCRIPTION
Ansible runs `apt update` when `update_cache` is enabled. Cache update might be a long operation (depending on the number of sources).

This change makes subsequent role runs much faster.