### PR TITLE
Fix "no passphrase" case

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,10 +64,6 @@ $ kitchen login
 Because of limitations, some shims are put in place like mapping /dev/urandom to /dev/random so gpg key generation can happen. Normally rng-tools or haveged are taking care of that.
 
 
-## Troubleshooting & Known issues
-
-* On bionic with GPG 2.1, you must provide passphrase else you will have an ioctl error or add to gen-key template '%no-protection'.
-
 ## License
 
 BSD 2-clause

--- a/README.md
+++ b/README.md
@@ -33,23 +33,21 @@ By default, role is retrieving armored public key and fingerprint to orchestrato
 
 ## Variables
 
+Complete list of available variables can be found in
+[defaults/main.yml](defaults/main.yml).
+
+Notable variables are:
 ```
+gpg_generator_user: "{{ ansible_ssh_user }}"
 gpg_user: "{{ ansible_ssh_user }}"
+
 gpg_realname: "GPG Ansible user"
-#gpg_userhome:
 gpg_useremail: "{{ gpg_user }}@localhost"
-gpg_pubkeyfile: "{{ gpg_user }}.pub"
-gpg_privkeyfile: "{{ gpg_user }}.priv"
-gpg_pubkeyfileexport: "{{ gpg_user }}.asc"
-gpg_fingerprint: "{{ gpg_user }}-fingerprint"
+gpg_passphrase: "Passphrase_example.CHANGE_ME!"
 
 gpg_keylength: 2048
 gpg_subkeylength: 2048
 gpg_expire: 360
-
-## recover files on orchestrator?
-gpg_pull: true
-
 ```
 
 ## Continuous integration
@@ -73,6 +71,3 @@ Because of limitations, some shims are put in place like mapping /dev/urandom to
 ## License
 
 BSD 2-clause
-
-
-

--- a/templates/gen-key-script
+++ b/templates/gen-key-script
@@ -13,6 +13,7 @@ Expire-Date: {{ gpg_expire }}
 Passphrase: {{ gpg_passphrase }}
 {% else %}
 %no-ask-passphrase
+%no-protection
 {% endif %}
 %pubring {{ gpg_pubkeyfile }}
 {% if (ansible_distribution == 'Ubuntu' and ansible_distribution_major_version|int <= 16) or (ansible_os_family == 'RedHat' and ansible_distribution_major_version|int <= 7) %}


### PR DESCRIPTION
Included changes:
- added `%no-protection` statement when passphrase is not provided
- added link to variables file in README (provided variables list was outdated), most notable variables are inlined in README
- removed `%no-protection` workaround from README

Based on `Troubleshooting & Known issues` block in README I can conclude, that you've been aware of that issue. However I think it is time to apply fix for everyone. Reasoning:
- GnuPG 2.1 (which is affected by this issue) was released [more than 6 years ago](https://gnupg.org/download/release_notes.html)
- `%no-protection` statement was available for [at least 10 years](https://github.com/gpg/gnupg/blame/31f548a18aed729c05ea367f2d8a8104480430d5/doc/gpg.texi#L3221), so it should be safe to use it even for older releases
- there have been 2 LTS Ubuntu releases with GnuPG 2.1 or above (other distributions probably use recent GnuPG too), so majority of potential users are affected by this issue

WDYT?