### PR TITLE
Restrict secret key creation failure messages

### DIFF
--- a/tasks/gpgkey_generate.yml
+++ b/tasks/gpgkey_generate.yml
@@ -106,11 +106,11 @@
 - name: Check existing secret key
   ansible.builtin.shell: "gpg --homedir {{ gpg_home }}/.gnupg --list-secret-keys | grep '{{ gpg_realname }}'"
   changed_when: false
-  ignore_errors: true
   become: yes
   become_user: "{{ gpg_generator_user }}"
   register: gpgkeys
   no_log: "{{ gpg_no_log }}"
+  failed_when: gpgkeys.rc > 1
 - name: Debug | gpg keys
   ansible.builtin.debug:
     var: gpgkeys


### PR DESCRIPTION
GPG error 1 is used for things like "gpg had to create its home directory" so rather than ignoring all errors we're accepting error 1 as a part of life. This may or may not have other implications but appears OK in my testing.