### PR TITLE
Remove unused keylength variables and add gpg_algo

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,9 +45,8 @@ gpg_realname: "GPG Ansible user"
 gpg_useremail: "{{ gpg_user }}@localhost"
 gpg_passphrase: "Passphrase_example.CHANGE_ME!"
 
-gpg_keylength: 2048
-gpg_subkeylength: 2048
 gpg_expire: 360
+gpg_algo: future-default # Uses the expected future default algorithm for GPG. Alternatives are e.g. rsa4096.
 ```
 
 ## Continuous integration

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -16,8 +16,7 @@ gpg_privkeyfile: "{{ gpg_user }}.priv"
 gpg_pubkeyfileexport: "{{ gpg_user }}.asc"
 gpg_fingerprint: "{{ gpg_user }}-fingerprint"
 
-gpg_keylength: 2048
-gpg_subkeylength: 2048
+gpg_algo: future-default
 gpg_expire: 360
 
 gpg_no_log: true

--- a/tasks/gpgkey_generate.yml
+++ b/tasks/gpgkey_generate.yml
@@ -128,7 +128,7 @@
     gpg --batch --homedir "{{ gpg_home }}/.gnupg"
         --passphrase-file "{{ gpg_home + '/' + gpg_passphrase_file }}"
         --quick-generate-key "{{ gpg_realname }} {{ gpg_useremail }}"
-        future-default default "{{ gpg_expire | default('10y') }}"
+        {{ gpg_algo }} default "{{ gpg_expire | default('10y') }}"
   args:
     chdir: "{{ gpg_home }}"
   become: yes


### PR DESCRIPTION
Thanks for working on this great role!

I was a bit confused by the `gpg_keylength` and `gpg_subkeylength` variables that were advertised in the README and defined in the `defaults/main.yml`. It seemed these are unused by the code, and there is no way to control algorithm and keylength. This PR replaces the unused length variables with `gpg_algo`, which defaults to `future-default`, but can also be set to require a specific algorithm and keylength (e.g. `rsa4096`).